### PR TITLE
chore: correctly validate share proof

### DIFF
--- a/types/share_proof.go
+++ b/types/share_proof.go
@@ -72,7 +72,7 @@ func (sp ShareProof) Validate(root []byte) error {
 	numberOfSharesInProofs := int32(0)
 	for _, proof := range sp.ShareProofs {
 		// the range is not inclusive from the left.
-		numberOfSharesInProofs = proof.End - proof.Start
+		numberOfSharesInProofs += proof.End - proof.Start
 	}
 
 	if len(sp.ShareProofs) != len(sp.RowProof.RowRoots) {


### PR DESCRIPTION
---

Validation was only taking the share number of the final proof. Fixes `TestShareInclusionProof` in celestia-app

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments
